### PR TITLE
Bind reactor to thread

### DIFF
--- a/src/protocol/impls.rs
+++ b/src/protocol/impls.rs
@@ -167,6 +167,15 @@ impl ProtocolMessage {
         payload
     }
 
+    pub fn try_write<W>(self, mut writer: W) -> io::Result<usize>
+    where
+        W: io::Write,
+    {
+        let message = self.into_adapter_message();
+
+        writer.write(message.as_ref())
+    }
+
     pub fn try_from_json_bytes<B>(bytes: B) -> Result<Self, Error>
     where
         B: AsRef<[u8]>,


### PR DESCRIPTION
**Describe the change**
This commit introduces the default bind behavior of the reactor to have its loop in a dedicated thread.

Previously, this was left for the user to decide, but then we might want to avoid complicated schemes to interact with the created service such as admin channels. Instead, the bind function will simply return the allocated socket for the listener, and any interaction with the reactor backend should be done from that entrypoint.

**Introduced tech-debts**
The user will no longer control the thread allocation of the bind service. However, there is no clear use-case of when the user might want to do that

**Base issue**
Resolves #0

**Related issues**

**Additional context**

**Checklist**
- [x] If its a bug, the branch is `bug/<user>/<issue>-short-title`. Example: `bug/vlopes11/28-stack-overflow`
- [x] If its a feature, the branch is `feature/<user>/<issue>-short-title`. Example: `feature/vlopes11/83-dynamic-menu`
- [x] I have performed a self-review of my code
- [x] If its a bug, I have added negative tests that will demonstrate it is fixed.
- [x] If its a feature, I have added unit and integrated tests.
- [x] I have succinctly documented the changes.
- [x] I have added the label `breaking change` if a public API changed either its signature or output logic.
- [x] If I used `unsafe` code, I added a comment on the line immediately above with a `Safety` remark, explaining why its usage won't cause undefined behavior if the user follow the constraints described in the documentation.
- [x] If my public function can panic, I added a `# Panics` section in the function documentation.
