### PR TITLE
Decouple reactor bind from listen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dap-reactor"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Codex Dev <contact@codx.io>"]
 categories = ["development-tools::debugging"]
 edition = "2021"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -60,5 +60,8 @@ async fn main() {
         .with_capacity(50)
         .bind("127.0.0.1:5647")
         .await
+        .expect("failed to init service")
+        .listen()
+        .await
         .expect("failed to run service");
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -80,234 +81,263 @@ where
         self
     }
 
-    pub async fn bind<S>(&mut self, socket: S) -> io::Result<()>
+    pub async fn bind<S>(&mut self, socket: S) -> io::Result<ReactorListener<B>>
     where
         S: net::ToSocketAddrs,
     {
-        bind::<B, _>(self.capacity, socket).await
+        let listener = net::TcpListener::bind(socket).await?;
+
+        Ok(ReactorListener {
+            capacity: self.capacity,
+            listener,
+            provider: PhantomData,
+        })
     }
 }
 
-/// Listen in a socket using the provided capacity for the used channels
-async fn bind<B, S>(capacity: usize, socket: S) -> io::Result<()>
+pub struct ReactorListener<B> {
+    capacity: usize,
+    listener: net::TcpListener,
+    provider: PhantomData<B>,
+}
+
+impl<B> Deref for ReactorListener<B> {
+    type Target = net::TcpListener;
+
+    fn deref(&self) -> &Self::Target {
+        &self.listener
+    }
+}
+
+impl<B> ReactorListener<B>
 where
     B: Backend + Send,
-    S: net::ToSocketAddrs,
 {
-    let listener = net::TcpListener::bind(socket).await?;
-
-    tracing::info!(
-        "listening on {}",
-        listener
+    pub async fn listen(self) -> io::Result<()> {
+        let socket = self
             .local_addr()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
-    );
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-    loop {
-        match listener.accept().await {
-            Ok((stream, addr)) => {
-                tracing::trace!("incoming connection from {}", addr);
+        tracing::info!("listening on {}", socket);
 
-                // this service is not particularly expected to be target of adversarial
-                // clients. this way, we can simplify the implementation with a naive approach
-                // to spawn threads for every socket.
-                //
-                // this is easily attacked by malicious clients because they can send huge
-                // amounts of connections and it would quickly exhaust the reactor. if this
-                // becomes a concern, we can alternatively use some server implementation that
-                // treats such cases for us - as example, actix-server. it will distribute the
-                // incoming requests around a given number of workers
+        let Self {
+            capacity, listener, ..
+        } = self;
 
-                let (events_tx, events_rx) = mpsc::channel::<Event>(capacity);
-                let (requests_tx, requests_rx) = mpsc::channel::<ReactorReverseRequest>(capacity);
-                let (mut events, mut requests) = (events_rx, requests_rx);
+        loop {
+            match listener.accept().await {
+                Ok((stream, addr)) => {
+                    tracing::trace!("incoming connection from {}", addr);
 
-                // overflowing a seq in a DAP usage is not really feasible since the limit of
-                // u64 is far beyond any normal usage. so we don't really need to put some
-                // special guard here to check for overflows and we can just benefit from
-                // atomic performance and security
-                let seq_event = Arc::new(AtomicU64::new(1));
-                let seq_request = Arc::clone(&seq_event);
-                let seq_reverse = Arc::clone(&seq_event);
+                    // this service is not particularly expected to be target of adversarial
+                    // clients. this way, we can simplify the implementation with a naive approach
+                    // to spawn threads for every socket.
+                    //
+                    // this is easily attacked by malicious clients because they can send huge
+                    // amounts of connections and it would quickly exhaust the reactor. if this
+                    // becomes a concern, we can alternatively use some server implementation that
+                    // treats such cases for us - as example, actix-server. it will distribute the
+                    // incoming requests around a given number of workers
 
-                let (inbound, outbound) = stream.into_split();
+                    let (events_tx, events_rx) = mpsc::channel::<Event>(capacity);
+                    let (requests_tx, requests_rx) =
+                        mpsc::channel::<ReactorReverseRequest>(capacity);
+                    let (mut events, mut requests) = (events_rx, requests_rx);
 
-                let outbound = sync::RwLock::new(outbound);
-                let outbound_event = Arc::new(outbound);
-                let outbound_request = Arc::clone(&outbound_event);
-                let outbound_reverse = Arc::clone(&outbound_event);
+                    // overflowing a seq in a DAP usage is not really feasible since the limit of
+                    // u64 is far beyond any normal usage. so we don't really need to put some
+                    // special guard here to check for overflows and we can just benefit from
+                    // atomic performance and security
+                    let seq_event = Arc::new(AtomicU64::new(1));
+                    let seq_request = Arc::clone(&seq_event);
+                    let seq_reverse = Arc::clone(&seq_event);
 
-                // thread to handle outbound events generated by the backend
-                tokio::spawn(async move {
-                    let outbound = outbound_event;
-                    let seq = seq_event;
+                    let (inbound, outbound) = stream.into_split();
 
-                    while let Some(ev) = events.recv().await {
-                        let seq = seq.fetch_add(1, Ordering::SeqCst);
+                    let outbound = sync::RwLock::new(outbound);
+                    let outbound_event = Arc::new(outbound);
+                    let outbound_request = Arc::clone(&outbound_event);
+                    let outbound_reverse = Arc::clone(&outbound_event);
 
-                        let ev = ev.into_protocol(seq);
-                        let ev = ProtocolMessage::from(ev);
-                        let ev = ev.into_adapter_message();
+                    // thread to handle outbound events generated by the backend
+                    tokio::spawn(async move {
+                        let outbound = outbound_event;
+                        let seq = seq_event;
 
-                        if let Err(e) = outbound.write().await.write_all(ev.as_bytes()).await {
-                            tracing::error!("error sending event: {}", e);
-                        }
-                    }
-                });
+                        while let Some(ev) = events.recv().await {
+                            let seq = seq.fetch_add(1, Ordering::SeqCst);
 
-                // thread to handle reverse requests from the backend to the client
-                tokio::spawn(async move {
-                    let seq = seq_reverse;
-                    let outbound = outbound_reverse;
+                            let ev = ev.into_protocol(seq);
+                            let ev = ProtocolMessage::from(ev);
+                            let ev = ev.into_adapter_message();
 
-                    while let Some(re) = requests.recv().await {
-                        let seq = re.id.unwrap_or_else(|| seq.fetch_add(1, Ordering::SeqCst));
-                        let request = re.request.into_protocol(seq);
-                        let request = ProtocolMessage::from(request);
-                        let request = request.into_adapter_message();
-
-                        if let Err(e) = outbound.write().await.write_all(request.as_bytes()).await {
-                            tracing::error!("error sending reverse request: {}", e);
-                        }
-                    }
-                });
-
-                // thread to handle inbound requests to be processed by the backend
-                tokio::spawn(async move {
-                    let mut backend = B::init(events_tx, requests_tx).await;
-                    let seq = seq_request;
-
-                    let mut buffer = tokio::io::BufReader::new(inbound);
-                    let outbound = outbound_request;
-
-                    loop {
-                        let len;
-                        let mut consumed = 0;
-
-                        // attempt to fetch content-length
-                        {
-                            let mut lines = (&mut buffer).lines();
-
-                            loop {
-                                let line = match lines.next_line().await {
-                                    Ok(Some(l)) => l.to_ascii_lowercase(),
-                                    Ok(None) => return,
-                                    Err(_e) => return,
-                                };
-
-                                consumed += line.len() + 1;
-
-                                let value = match line.trim_end_matches('\r').split_once(": ") {
-                                    Some((key, value)) if key == "content-length" => value,
-                                    _ => continue,
-                                };
-
-                                len = match value.parse::<usize>() {
-                                    Ok(n) => n,
-                                    Err(e) => {
-                                        tracing::warn!("invalid content-lenght: {}", e);
-                                        continue;
-                                    }
-                                };
-
-                                break;
+                            if let Err(e) = outbound.write().await.write_all(ev.as_bytes()).await {
+                                tracing::error!("error sending event: {}", e);
                             }
+                        }
+                    });
 
-                            // skip while line not empty
-                            loop {
-                                let line = match lines.next_line().await {
-                                    Ok(Some(l)) => l,
-                                    _ => return,
-                                };
+                    // thread to handle reverse requests from the backend to the client
+                    tokio::spawn(async move {
+                        let seq = seq_reverse;
+                        let outbound = outbound_reverse;
 
-                                consumed += line.len() + 1;
+                        while let Some(re) = requests.recv().await {
+                            let seq = re.id.unwrap_or_else(|| seq.fetch_add(1, Ordering::SeqCst));
+                            let request = re.request.into_protocol(seq);
+                            let request = ProtocolMessage::from(request);
+                            let request = request.into_adapter_message();
 
-                                if line.trim_end_matches('\r').is_empty() {
+                            if let Err(e) =
+                                outbound.write().await.write_all(request.as_bytes()).await
+                            {
+                                tracing::error!("error sending reverse request: {}", e);
+                            }
+                        }
+                    });
+
+                    // thread to handle inbound requests to be processed by the backend
+                    tokio::spawn(async move {
+                        let mut backend = B::init(events_tx, requests_tx).await;
+                        let seq = seq_request;
+
+                        let mut buffer = tokio::io::BufReader::new(inbound);
+                        let outbound = outbound_request;
+
+                        loop {
+                            let len;
+                            let mut consumed = 0;
+
+                            // attempt to fetch content-length
+                            {
+                                let mut lines = (&mut buffer).lines();
+
+                                loop {
+                                    let line = match lines.next_line().await {
+                                        Ok(Some(l)) => l.to_ascii_lowercase(),
+                                        Ok(None) => return,
+                                        Err(_e) => return,
+                                    };
+
+                                    consumed += line.len() + 1;
+
+                                    let value = match line.trim_end_matches('\r').split_once(": ") {
+                                        Some((key, value)) if key == "content-length" => value,
+                                        _ => continue,
+                                    };
+
+                                    len = match value.parse::<usize>() {
+                                        Ok(n) => n,
+                                        Err(e) => {
+                                            tracing::warn!("invalid content-lenght: {}", e);
+                                            continue;
+                                        }
+                                    };
+
                                     break;
                                 }
-                            }
-                        }
 
-                        let mut content = vec![0u8; len];
+                                // skip while line not empty
+                                loop {
+                                    let line = match lines.next_line().await {
+                                        Ok(Some(l)) => l,
+                                        _ => return,
+                                    };
 
-                        if let Err(e) = buffer.read_exact(&mut content).await {
-                            tracing::warn!("couldn't read message len: {}", e);
-                            continue;
-                        }
+                                    consumed += line.len() + 1;
 
-                        buffer.consume(len + consumed);
-
-                        let message = match ProtocolMessage::try_from_json_bytes(content) {
-                            Ok(m) => m,
-                            Err(e) => {
-                                tracing::warn!("invalid message: {}", e);
-                                continue;
-                            }
-                        };
-
-                        tracing::debug!("received message {:?}", message);
-
-                        let request = match message {
-                            ProtocolMessage::Request(re) => re,
-
-                            ProtocolMessage::Response(re) => {
-                                let id = re.request_seq;
-
-                                let response = match Response::try_from(&re) {
-                                    Ok(re) => re,
-                                    Err(e) => {
-                                        tracing::debug!(
-                                            "error parsing a response from the client: {}",
-                                            e
-                                        );
-                                        continue;
+                                    if line.trim_end_matches('\r').is_empty() {
+                                        break;
                                     }
-                                };
+                                }
+                            }
 
-                                backend.response(id, response).await;
+                            let mut content = vec![0u8; len];
+
+                            if let Err(e) = buffer.read_exact(&mut content).await {
+                                tracing::warn!("couldn't read message len: {}", e);
                                 continue;
                             }
 
-                            ProtocolMessage::Event(ev) => {
-                                tracing::debug!("received unexpected event from client: {:?}", ev);
-                                continue;
+                            buffer.consume(len + consumed);
+
+                            let message = match ProtocolMessage::try_from_json_bytes(content) {
+                                Ok(m) => m,
+                                Err(e) => {
+                                    tracing::warn!("invalid message: {}", e);
+                                    continue;
+                                }
+                            };
+
+                            tracing::debug!("received message {:?}", message);
+
+                            let request = match message {
+                                ProtocolMessage::Request(re) => re,
+
+                                ProtocolMessage::Response(re) => {
+                                    let id = re.request_seq;
+
+                                    let response = match Response::try_from(&re) {
+                                        Ok(re) => re,
+                                        Err(e) => {
+                                            tracing::debug!(
+                                                "error parsing a response from the client: {}",
+                                                e
+                                            );
+                                            continue;
+                                        }
+                                    };
+
+                                    backend.response(id, response).await;
+                                    continue;
+                                }
+
+                                ProtocolMessage::Event(ev) => {
+                                    tracing::debug!(
+                                        "received unexpected event from client: {:?}",
+                                        ev
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            let request_seq = request.seq;
+                            let request = match Request::try_from(&request) {
+                                Ok(re) => re,
+
+                                Err(e) => {
+                                    tracing::debug!("received invalid request from client: {}", e);
+                                    continue;
+                                }
+                            };
+
+                            let response = match backend.request(request).await {
+                                Some(re) => re,
+
+                                None => {
+                                    tracing::debug!("request didn't produce a response");
+                                    continue;
+                                }
+                            };
+
+                            let seq = seq.fetch_add(1, Ordering::SeqCst);
+                            let response = response.into_protocol(seq, request_seq);
+                            let response =
+                                ProtocolMessage::Response(response).into_adapter_message();
+
+                            tracing::debug!("outbound {:?}", response);
+
+                            if let Err(e) =
+                                outbound.write().await.write_all(response.as_bytes()).await
+                            {
+                                tracing::error!("error sending response: {}", e);
                             }
-                        };
-
-                        let request_seq = request.seq;
-                        let request = match Request::try_from(&request) {
-                            Ok(re) => re,
-
-                            Err(e) => {
-                                tracing::debug!("received invalid request from client: {}", e);
-                                continue;
-                            }
-                        };
-
-                        let response = match backend.request(request).await {
-                            Some(re) => re,
-
-                            None => {
-                                tracing::debug!("request didn't produce a response");
-                                continue;
-                            }
-                        };
-
-                        let seq = seq.fetch_add(1, Ordering::SeqCst);
-                        let response = response.into_protocol(seq, request_seq);
-                        let response = ProtocolMessage::Response(response).into_adapter_message();
-
-                        tracing::debug!("outbound {:?}", response);
-
-                        if let Err(e) = outbound.write().await.write_all(response.as_bytes()).await
-                        {
-                            tracing::error!("error sending response: {}", e);
                         }
-                    }
-                });
-            }
+                    });
+                }
 
-            Err(e) => tracing::error!("error accepting socket: {}", e),
+                Err(e) => tracing::error!("error accepting socket: {}", e),
+            }
         }
     }
 }


### PR DESCRIPTION
**Describe the change**
This commit decouples the `listen` action from the `bind` address.

It is desirable to allow the user to fetch the used socket from the listener and to bind the reactor socket as he wishes - either in a dedicated worker thread or in the current main thread.

For type safety, a new type `ReactorListener` is introduced, and this can be created only from `Reactor::bind`. The reactor will deref non-mutable to tokio listener, and this will give freedom to the user to query anything of relevance directly from the listener, without mutating it.

When the user consumes the listener, an events loop will start in the current thread. The user is free to move the listener to a dedicated thread, or just listen in the current one.

**Introduced tech-debts**
We need to add tests to bind, connect and serve to reactor

**Base issue**
Resolves #0

**Related issues**

**Additional context**

**Checklist**
- [x] If its a bug, the branch is `bug/<user>/<issue>-short-title`. Example: `bug/vlopes11/28-stack-overflow`
- [x] If its a feature, the branch is `feature/<user>/<issue>-short-title`. Example: `feature/vlopes11/83-dynamic-menu`
- [x] I have performed a self-review of my code
- [x] If its a bug, I have added negative tests that will demonstrate it is fixed.
- [x] If its a feature, I have added unit and integrated tests.
- [x] I have succinctly documented the changes.
- [x] I have added the label `breaking change` if a public API changed either its signature or output logic.
- [x] If I used `unsafe` code, I added a comment on the line immediately above with a `Safety` remark, explaining why its usage won't cause undefined behavior if the user follow the constraints described in the documentation.
- [x] If my public function can panic, I added a `# Panics` section in the function documentation.
