### PR TITLE
Add `Client` to consume `Reactor`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "A debug adapter protocol Rust provider."
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
+bytes = { version = "1.2", optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 tokio = { version = "1.21", optional = true, features = ["io-util", "net", "rt", "sync"] }
 tracing = { version = "0.1", optional = true }
@@ -21,7 +22,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 default = ["reactor", "serde_json/default"]
-reactor = ["async-trait", "tracing", "tokio"]
+reactor = ["async-trait", "bytes", "tracing", "tokio"]
 
 [[example]]
 name = "async"

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -1,3 +1,8 @@
+mod client;
+
+#[cfg(test)]
+mod tests;
+
 use std::io;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -14,6 +19,7 @@ use crate::request::{Request, ReverseRequest};
 use crate::response::Response;
 
 pub use async_trait::async_trait;
+pub use client::*;
 pub use serde_json::Value;
 pub use tokio::sync::mpsc::Sender;
 

--- a/src/reactor/client.rs
+++ b/src/reactor/client.rs
@@ -1,0 +1,194 @@
+use std::io;
+
+use bytes::BytesMut;
+use tokio::net;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::SendError;
+use tokio::task;
+
+use crate::event::Event;
+use crate::protocol::ProtocolMessage;
+use crate::request::Request;
+use crate::response::Response;
+
+pub struct ClientBuilder {
+    pub capacity: usize,
+    pub buffer: usize,
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClientBuilder {
+    pub fn new() -> Self {
+        Self {
+            capacity: 50,
+            buffer: 4096,
+        }
+    }
+
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = capacity;
+        self
+    }
+
+    pub fn with_buffer(mut self, buffer: usize) -> Self {
+        self.buffer = buffer;
+        self
+    }
+
+    pub async fn connect<S>(self, socket: S) -> io::Result<Client>
+    where
+        S: net::ToSocketAddrs,
+    {
+        let Self { capacity, buffer } = self;
+
+        Client::connect(capacity, buffer, socket).await
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientRequest {
+    pub seq: Option<u64>,
+    pub request: Request,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientResponse {
+    pub seq: u64,
+    pub response: Response,
+}
+
+pub struct Client {
+    pub responses: mpsc::Receiver<ClientResponse>,
+    pub events: mpsc::Receiver<Event>,
+    pub requests: mpsc::Sender<ClientRequest>,
+    pub inbound: task::JoinHandle<()>,
+    pub outbound: task::JoinHandle<()>,
+}
+
+impl Client {
+    pub async fn connect<S>(capacity: usize, buffer: usize, socket: S) -> io::Result<Self>
+    where
+        S: net::ToSocketAddrs,
+    {
+        let (read, write) = net::TcpStream::connect(socket).await?.into_split();
+
+        let (responses_tx, responses) = mpsc::channel(capacity);
+        let (events_tx, events) = mpsc::channel(capacity);
+        let (requests, mut requests_rx) = mpsc::channel(capacity);
+
+        let inbound = tokio::spawn(async move {
+            let mut buf = BytesMut::with_capacity(buffer);
+
+            while read.readable().await.is_ok() {
+                let n = match read.try_read_buf(&mut buf) {
+                    Ok(n) => n,
+                    Err(_) => continue,
+                };
+
+                let mut bytes = &buf.as_ref()[..n];
+
+                while !bytes.is_empty() {
+                    let message = match ProtocolMessage::try_from_bytes(bytes) {
+                        Ok((n, message)) => {
+                            bytes = &bytes[n..];
+                            message
+                        }
+                        Err(e) => {
+                            tracing::warn!("invalid message received: {}", e);
+                            continue;
+                        }
+                    };
+
+                    match message {
+                        ProtocolMessage::Request(_) => {
+                            tracing::warn!("unexpected request from backend");
+                        }
+
+                        ProtocolMessage::Response(re) => {
+                            let seq = re.request_seq;
+
+                            match Response::try_from(&re) {
+                                Ok(response) => {
+                                    if let Err(e) =
+                                        responses_tx.send(ClientResponse { seq, response }).await
+                                    {
+                                        tracing::error!("error submitting response: {}", e);
+                                    }
+                                }
+
+                                Err(e) => {
+                                    tracing::warn!("invalid response received: {}", e);
+                                }
+                            };
+                        }
+
+                        ProtocolMessage::Event(ev) => match Event::try_from(&ev) {
+                            Ok(ev) => {
+                                if let Err(e) = events_tx.send(ev).await {
+                                    tracing::error!("error submitting event: {}", e);
+                                }
+                            }
+
+                            Err(e) => {
+                                tracing::warn!("invalid event received: {}", e);
+                            }
+                        },
+                    }
+                }
+
+                buf.clear();
+            }
+        });
+
+        let outbound = tokio::spawn(async move {
+            let mut id = 0u64;
+
+            while let Some(ClientRequest { seq, request }) = requests_rx.recv().await {
+                if write.writable().await.is_err() {
+                    break;
+                }
+
+                id = seq.unwrap_or_else(|| id.wrapping_add(1).min(1));
+
+                let request = request.into_protocol(id);
+                let message = ProtocolMessage::from(request).into_adapter_message();
+
+                if let Err(e) = write.try_write(message.as_bytes()) {
+                    tracing::error!("error sending request: {}", e);
+                }
+            }
+        });
+
+        Ok(Self {
+            responses,
+            events,
+            requests,
+            inbound,
+            outbound,
+        })
+    }
+
+    pub async fn request(&self, request: Request) -> Result<(), SendError<ClientRequest>> {
+        self.requests
+            .send(ClientRequest { seq: None, request })
+            .await
+    }
+
+    pub async fn request_with_seq(
+        &self,
+        seq: u64,
+        request: Request,
+    ) -> Result<(), SendError<ClientRequest>> {
+        self.requests
+            .send(ClientRequest {
+                seq: Some(seq),
+                request,
+            })
+            .await
+    }
+}

--- a/src/reactor/tests.rs
+++ b/src/reactor/tests.rs
@@ -1,0 +1,137 @@
+use std::io;
+
+use crate::prelude::*;
+
+struct Service;
+
+impl Service {
+    pub fn capabilities() -> Capabilities {
+        Capabilities {
+            supports_configuration_done_request: true,
+            supports_function_breakpoints: true,
+            supports_conditional_breakpoints: true,
+            supports_hit_conditional_breakpoints: true,
+            supports_evaluate_for_hovers: true,
+            exception_breakpoint_filters: vec![],
+            supports_step_back: true,
+            supports_set_variable: false,
+            supports_restart_frame: false,
+            supports_goto_targets_request: false,
+            supports_step_in_targets_request: false,
+            supports_completions_request: false,
+            completion_trigger_characters: vec![],
+            supports_modules_request: false,
+            additional_module_columns: vec![],
+            supported_checksum_algorithms: vec![
+                ChecksumAlgorithm::Md5,
+                ChecksumAlgorithm::Sha1,
+                ChecksumAlgorithm::Sha256,
+                ChecksumAlgorithm::Timestamp,
+            ],
+            supports_restart_request: true,
+            supports_exception_options: false,
+            supports_value_formatting_options: false,
+            supports_exception_info_request: false,
+            support_terminate_debuggee: true,
+            support_suspend_debuggee: true,
+            supports_delayed_stack_trace_loading: false,
+            supports_loaded_sources_request: true,
+            supports_log_points: true,
+            supports_terminate_threads_request: true,
+            supports_set_expression: false,
+            supports_terminate_request: true,
+            supports_data_breakpoints: true,
+            supports_read_memory_request: false,
+            supports_write_memory_request: false,
+            supports_disassemble_request: false,
+            supports_cancel_request: false,
+            supports_breakpoint_locations_request: true,
+            supports_clipboard_context: false,
+            supports_stepping_granularity: false,
+            supports_instruction_breakpoints: false,
+            supports_exception_filter_options: false,
+            supports_single_thread_execution_requests: true,
+        }
+    }
+}
+
+#[async_trait]
+impl Backend for Service {
+    async fn init(_events: Sender<Event>, _requests: Sender<ReactorReverseRequest>) -> Self {
+        Self
+    }
+
+    async fn request(&mut self, request: Request) -> Option<Response> {
+        match request {
+            Request::Initialize {
+                arguments: InitializeArguments { .. },
+            } => Some(Response::Initialize {
+                body: Self::capabilities(),
+            }),
+            _ => None,
+        }
+    }
+
+    async fn response(&mut self, _id: u64, _response: Response) {}
+}
+
+#[tokio::test]
+async fn initialize_works() -> io::Result<()> {
+    let reactor = Reactor::<Service>::new()
+        .with_capacity(50)
+        .bind("127.0.0.1:0")
+        .await?;
+
+    let socket = reactor.local_addr()?;
+
+    tokio::spawn(async move {
+        reactor.listen().await.ok();
+    });
+
+    let mut client = ClientBuilder::new().connect(socket).await?;
+
+    client
+        .requests
+        .send(ClientRequest {
+            seq: None,
+            request: Request::Initialize {
+                arguments: InitializeArguments {
+                    client_id: None,
+                    client_name: None,
+                    adapter_id: "foo".into(),
+                    locale: None,
+                    lines_start_at_1: true,
+                    column_start_at_1: true,
+                    path_format: None,
+                    supports_variable_type: true,
+                    supports_variable_paging: false,
+                    supports_run_in_terminal_request: false,
+                    supports_memory_references: false,
+                    supports_progress_reporting: false,
+                    supports_invalidated_event: false,
+                    supports_memory_event: false,
+                    supports_args_can_be_interpreted_by_shell: false,
+                },
+            },
+        })
+        .await
+        .expect("failed to submit request");
+
+    let re = client
+        .responses
+        .recv()
+        .await
+        .expect("a response was expected");
+
+    let capabilities = match re.response {
+        Response::Initialize { body } => Ok(body),
+        _ => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "wrong response variant",
+        )),
+    }?;
+
+    assert_eq!(Service::capabilities(), capabilities);
+
+    Ok(())
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -208,6 +208,23 @@ impl TryFrom<&ProtocolResponse> for Response {
             "evaluate" => Ok(Self::Evaluate {
                 body: EvaluateResponse::try_from(result)?,
             }),
+            "exceptionInfo" => Ok(Self::ExceptionInfo {
+                body: ExceptionInfoResponse::try_from(result)?,
+            }),
+            "goto" => Ok(Self::Goto),
+            "initialize" => Ok(Self::Initialize {
+                body: InitializeResponse::try_from(result)?,
+            }),
+            "launch" => Ok(Self::Launch),
+            "loadedSources" => Ok(Self::LoadedSources {
+                body: LoadedSourcesResponse::try_from(result)?,
+            }),
+            "next" => Ok(Self::Next),
+            "reverseContinue" => Ok(Self::ReverseContinue),
+            "setBreakpoints" => Ok(Self::SetBreakpoints {
+                body: SetBreakpointsResponse::try_from(result)?,
+            }),
+            "stepBack" => Ok(Self::StepBack),
             _ => Err(Error::new("response", Cause::ExpectsEnum)),
         }
     }


### PR DESCRIPTION
**Describe the change**
Add a `client` structure to manage the connection and protocol communication with the reactor

**Introduced tech-debts**
The client is based on channels and depends on concrete types. This means that we can't take requests as arguments without their seq that is defined in the protocol.

Also, possibly, the client should have a mechanism to request->response in the same call and manage internally the responses sent by the backend, either storing or skipping unexpected seqs.

**Base issue**
Resolves #0

**Related issues**

**Additional context**

**Checklist**
- [x] If its a bug, the branch is `bug/<user>/<issue>-short-title`. Example: `bug/vlopes11/28-stack-overflow`
- [x] If its a feature, the branch is `feature/<user>/<issue>-short-title`. Example: `feature/vlopes11/83-dynamic-menu`
- [x] I have performed a self-review of my code
- [x] If its a bug, I have added negative tests that will demonstrate it is fixed.
- [x] If its a feature, I have added unit and integrated tests.
- [x] I have succinctly documented the changes.
- [x] I have added the label `breaking change` if a public API changed either its signature or output logic.
- [x] If I used `unsafe` code, I added a comment on the line immediately above with a `Safety` remark, explaining why its usage won't cause undefined behavior if the user follow the constraints described in the documentation.
- [x] If my public function can panic, I added a `# Panics` section in the function documentation.
