### PR TITLE
Fix page breaking between messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,8 +19,8 @@ pub enum Cause {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Error {
-    attribute: &'static str,
-    cause: Cause,
+    pub attribute: &'static str,
+    pub cause: Cause,
 }
 
 impl Error {


### PR DESCRIPTION
**Describe the change**
If a message is sent with a length bigger than page, the reactor won't be able to parse it because the state is lost.

This commits fixes that problem, allowing arbitrary sized messages to be sent.

**Introduced tech-debts**
N/A

**Base issue**
N/A

**Related issues**
N/A

**Additional context**
N/A

**Checklist**
- [x] If its a bug, the branch is `bug/<user>/<issue>-short-title`. Example: `bug/vlopes11/28-stack-overflow`
- [x] If its a feature, the branch is `feature/<user>/<issue>-short-title`. Example: `feature/vlopes11/83-dynamic-menu`
- [x] I have performed a self-review of my code
- [x] If its a bug, I have added negative tests that will demonstrate it is fixed.
- [x] If its a feature, I have added unit and integrated tests.
- [x] I have succinctly documented the changes.
- [x] I have added the label `breaking change` if a public API changed either its signature or output logic.
- [x] If I used `unsafe` code, I added a comment on the line immediately above with a `Safety` remark, explaining why its usage won't cause undefined behavior if the user follow the constraints described in the documentation.
- [x] If my public function can panic, I added a `# Panics` section in the function documentation.
